### PR TITLE
Added exposure & gain set method to AcquisitionBuffer.

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -586,6 +586,20 @@ impl Camera {
         /// Read the sensor clock frequency in Hz
         sensor_clock_freq_hz: f32;
 
+        /// Data move policy
+        mut buffer_policy: i32;
+
+        /// Auto white balance mode.
+        mut auto_wb: i32;
+
+        /// White balance Red coefficient.
+        mut wb_kr: f32;
+
+        /// White balance Green coefficient.
+        mut wb_kg: f32;
+
+        /// White balance Blue coefficient.
+        mut wb_kb: f32;
     }
 }
 


### PR DESCRIPTION
Added param_suffix function to compose parameter name and info/modifiers.
Refactored param_info use this function.

Work in progress:
The parameter name b"exposure: direct_update" should be without
whitespace (as a combination of XI_PRM_EXPOSURE and
XI_PRMM_DIRECT_UPDATE. But it does not work. I had to add the space
to make it work.

The set_gain function uses add_suffix, the parameter name seems to
work but I get an error type invalid parameter. I did not figure out why
yet.