### PR TITLE
Fix memory leak on acquisition in SAFE_MODE.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 xiapi-sys = "0.1.1"
 paste = "1.0.6"
 image = { version = "0.24.2", optional= true}
-
+libc = "0.2"
 
 [dev-dependencies]
 serial_test = { version = "2.0.0", features = ["file_locks"] }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -586,6 +586,20 @@ impl Camera {
         /// Read the sensor clock frequency in Hz
         sensor_clock_freq_hz: f32;
 
+        /// Data move policy
+        mut buffer_policy: i32;
+
+        /// Auto white balance mode.
+        mut auto_wb: i32;
+
+        /// White balance Red coefficient.
+        mut wb_kr: f32;
+
+        /// White balance Green coefficient.
+        mut wb_kg: f32;
+
+        /// White balance Blue coefficient.
+        mut wb_kb: f32;
     }
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -132,6 +132,14 @@ impl<'a, T> Image<'a, T> {
     }
 }
 
+impl <'a, T> Drop for Image<'_,T>
+{
+    fn drop(&mut self) {
+        unsafe { libc::free(self.xi_img.bp as *mut libc::c_void); }
+    }
+}
+
+
 #[cfg(feature = "image")]
 impl<P> From<Image<'_, P::Subpixel>> for ImageBuffer<P, Vec<P::Subpixel>>
 where


### PR DESCRIPTION
The image allocated by xiGetBuffer in safe mode allocates a buffer that is never deallocated.
Since it i allocated by an external library, it must be freed through the libc::free function. It is done on the drop method of the Image class.

This patch is work in progress, as it won't work in UNSAFE_MODE. The acquisition mode could be stored in the image structure to  decide if the buffer must be deallocated or not.