### PR TITLE
Added proper error reporting in Camera::next_frame.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 xiapi-sys = "0.1.1"
 paste = "1.0.6"
 image = { version = "0.24.2", optional= true}
-
+libc = "0.2"
 
 [dev-dependencies]
 serial_test = { version = "2.0.0", features = ["file_locks"] }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -640,10 +640,13 @@ impl AcquisitionBuffer {
             xi_img,
             pix_type: PhantomData::default(),
         };
-        unsafe {
-            xiapi_sys::xiGetImage(self.camera.device_handle, timeout, &mut image.xi_img);
+        let ret_code = unsafe {
+            xiapi_sys::xiGetImage(self.camera.device_handle, timeout, &mut image.xi_img)
+        };
+        match ret_code as u32 {
+            xiapi_sys::XI_RET::XI_OK => Ok(image),
+            _ => Err(ret_code),
         }
-        Ok(image)
     }
 
     /// Send a software trigger signal to the camera.

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -586,6 +586,20 @@ impl Camera {
         /// Read the sensor clock frequency in Hz
         sensor_clock_freq_hz: f32;
 
+        /// Data move policy
+        mut buffer_policy: i32;
+
+        /// Auto white balance mode.
+        mut auto_wb: i32;
+
+        /// White balance Red coefficient.
+        mut wb_kr: f32;
+
+        /// White balance Green coefficient.
+        mut wb_kg: f32;
+
+        /// White balance Blue coefficient.
+        mut wb_kb: f32;
     }
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -132,6 +132,14 @@ impl<'a, T> Image<'a, T> {
     }
 }
 
+impl <'a, T> Drop for Image<'_,T>
+{
+    fn drop(&mut self) {
+        unsafe { libc::free(self.xi_img.bp as *mut libc::c_void); }
+    }
+}
+
+
 #[cfg(feature = "image")]
 impl<P> From<Image<'_, P::Subpixel>> for ImageBuffer<P, Vec<P::Subpixel>>
 where


### PR DESCRIPTION
Camera::next_frame was not reporting any error.
If an error occurs, it returns an image of size 0.

This PR allows returning the proper error code.