### PR TITLE
Fixed error reporting on camera::next_frame.

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -635,10 +635,13 @@ impl AcquisitionBuffer {
             xi_img,
             pix_type: PhantomData::default(),
         };
-        unsafe {
-            xiapi_sys::xiGetImage(self.camera.device_handle, timeout, &mut image.xi_img);
+        let ret_code = unsafe {
+            xiapi_sys::xiGetImage(self.camera.device_handle, timeout, &mut image.xi_img)
+        };
+        match ret_code as u32 {
+            xiapi_sys::XI_RET::XI_OK => Ok(image),
+            _ => Err(ret_code),
         }
-        Ok(image)
     }
 
     /// Send a software trigger signal to the camera.


### PR DESCRIPTION
The camera::next_frame function was always returnng Ok(img) even if there was an error (in this case, the image had a 0 size.
This PR fixes that.