### PR TITLE
Testing

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -638,10 +638,19 @@ impl AcquisitionBuffer {
             xi_img,
             pix_type: PhantomData::default(),
         };
-        unsafe {
-            xiapi_sys::xiGetImage(self.camera.device_handle, timeout, &mut image.xi_img);
+        let ret = unsafe {
+            xiapi_sys::xiGetImage(self.camera.device_handle, timeout, &mut image.xi_img)
+        };
+
+        match ret as XI_RET::Type{
+            XI_RET::XI_OK => {
+                Ok(image)
+            }
+            x => {
+               Err(x as XI_RETURN)
+            }
         }
-        Ok(image)
+
     }
 
     /// Send a software trigger signal to the camera.

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -602,6 +602,9 @@ impl Deref for Camera {
     }
 }
 
+unsafe impl Send for Camera {
+}
+
 impl AcquisitionBuffer {
     /// Stop the image acquisition.
     ///
@@ -660,4 +663,8 @@ impl AcquisitionBuffer {
     pub fn software_trigger(&mut self) -> Result<(), XI_RETURN> {
         unsafe { self.camera.set_param(XI_PRM_TRG_SOFTWARE, XI_SWITCH::XI_ON) }
     }
+}
+
+unsafe impl Send for AcquisitionBuffer{
+
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -132,6 +132,10 @@ impl<'a, T> Image<'a, T> {
     }
 }
 
+unsafe impl<'a,T> Send for Image<'a, T>{
+
+}
+
 #[cfg(feature = "image")]
 impl<P> From<Image<'_, P::Subpixel>> for ImageBuffer<P, Vec<P::Subpixel>>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     #[serial]
     fn read_counters() -> Result<(), XI_RETURN> {
-        let mut cam = open_device(None)?;
+        let mut cam = open_device_manual_bandwidth(None, 1000)?;
         let skipped_frames =
             cam.counter(XI_COUNTER_SELECTOR::XI_CNT_SEL_TRANSPORT_SKIPPED_FRAMES)?;
         assert_eq!(skipped_frames, 0);


### PR DESCRIPTION
Fixed a bug concerning the error reporting in AcquistionBuffer::next_image and add the send trait to Camera, Image and Acquisition buffer.
The fix for next_image is very similar to the one in #10.